### PR TITLE
fix: required hours to be paid in a collaboration scholarship

### DIFF
--- a/en/student-life/student-collaboration-scholarships.md
+++ b/en/student-life/student-collaboration-scholarships.md
@@ -3,11 +3,11 @@
 A student collaboration scholarship is a scholarship assigned to students that take part in various activity of support for Sapienza.
 
 Every scholarship covers **a maximum of 150 hours of activity** for a compensation of 1295€ (or 1500€, if the activity includes support for students with learning disorders). Generally, retribution is carried out in this way:
-- The student that completes less than 75 hours will not receive any amount of money;
+- The student that completes less than 25 hours will not receive any amount of money;
 - Once the student completes 75 hours, he/she receives half of the compensation;
 - The rest of the compensation is deposited either once he/she completes 150 hours of activity or when the scholarship ends; if when the scholarship ends the student has not finished 150 hours, the compensation will be proportional to the number of hours completed (for example, if the student does 100 hours, he/she will receive 865€, of which 650 when he/she completes 75 hours and the rest at the end of the scholarship).
 
-The students can decide to abandon the scholarship before it ends if he/she notifies the referent in time. The compensation will work in the same way: if he/she abandons before completing 75 hours he/she won't receive anything, otherwise he/she will receive a compensation proportional to the number of hours completed.
+The students can decide to abandon the scholarship before it ends if he/she notifies the referent in time. The compensation will work in the same way: if he/she abandons before completing 25 hours he/she won't receive anything, otherwise he/she will receive a compensation proportional to the number of hours completed.
 
 {{% hint warning %}}
 <i class="fa-solid fa-triangle-exclamation" style="color: #FFD43B;"></i> **Warning**

--- a/it/vita-studentesca/borse-di-collaborazione.md
+++ b/it/vita-studentesca/borse-di-collaborazione.md
@@ -3,11 +3,11 @@
 Una borsa di collaborazione è una borsa di studio assegnata a studenti che svolgono varie attività di supporto all'interno della Sapienza.
 
 Tutte le borse di collaborazione richiedono lo svolgimento di **150 ore di attività** in cambio di un compenso massimo di 1295€ (o di 1500€, in caso l'attività riguardi il supporto di studenti DSA). In genere la retribuzione avviene così:
-- Lo studente che svolge meno di 75 ore non riceve alcun compenso
+- Lo studente che svolge meno di 25 ore non riceve alcun compenso
 - Una volta che lo studente raggiunge 75 ore di attività riceve metà del compenso della borsa
 - Il resto del compenso viene versato o al raggiungimento delle 150 ore o al termine fissato dal bando per lo svolgimento dell'attività; se entro tale termine lo studente non ha raggiunto le 150 ore, il compenso versato sarà proporzionale al numero di ore svolte (ad esempio, 100 ore di attività corrispondono a circa 865€ di compenso, di cui 650€ vengono versati raggiunte le 75 ore e 215€ al termine della borsa)
 
-Lo studente può anche decidere di porre fine alla borsa prima del suo termine naturale, purché avvisi il proprio referente con anticipo. Il versamento del compenso rimane invariato: se lo studente ha svolto meno di 75 ore non riceve nessuna somma, altrimenti riceve una somma percentuale al numero di ore svolte prima della rinuncia.
+Lo studente può anche decidere di porre fine alla borsa prima del suo termine naturale, purché avvisi il proprio referente con anticipo. Il versamento del compenso rimane invariato: se lo studente ha svolto meno di 25 ore non riceve nessuna somma, altrimenti riceve una somma percentuale al numero di ore svolte prima della rinuncia.
 
 **Ogni studente può accedere a una sola borsa di collaborazione per anno accademico**. Nonostante ciò, può presentare domanda per più borse di collaborazione e poi sceglierne una.
 


### PR DESCRIPTION
You need 25 hours to get paid proportionally to the amount of hours actually worked.
But you will receive the first half of the compensation after having completed the first 75 hours out of 150.